### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ dependencies {
   <groupId>net.steppschuh.markdowngenerator</groupId>
   <artifactId>markdowngenerator</artifactId>
   <version>1.3.0.0</version>
-  <type>pom</type>
 </dependency>
 ```
 


### PR DESCRIPTION
http://stackoverflow.com/questions/12868537/netbeans-maven-dependencies-of-type-pom
I cannot import this dependency until I remove '<type>pom</type>'