### PR TITLE
fix: use platform indepentent line seperator

### DIFF
--- a/Source/MarkdownGenerator/src/main/java/net/steppschuh/markdowngenerator/list/UnorderedList.java
+++ b/Source/MarkdownGenerator/src/main/java/net/steppschuh/markdowngenerator/list/UnorderedList.java
@@ -43,7 +43,7 @@ public class UnorderedList<T extends Object> extends MarkdownElement {
             }
 
             if (itemIndex < items.size() - 1) {
-                sb.append("\n");
+                sb.append(System.lineSeparator());
             }
         }
         return sb.toString();

--- a/Source/MarkdownGenerator/src/main/java/net/steppschuh/markdowngenerator/table/Table.java
+++ b/Source/MarkdownGenerator/src/main/java/net/steppschuh/markdowngenerator/table/Table.java
@@ -111,7 +111,7 @@ public class Table extends MarkdownElement {
         String headerSeperator = generateHeaderSeperator(columnWidths, alignments);
         boolean headerSeperatorAdded = !firstRowIsHeader;
         if (!firstRowIsHeader) {
-            sb.append(headerSeperator).append("\n");
+            sb.append(headerSeperator).append(System.lineSeparator());
         }
 
         for (TableRow row : rows) {
@@ -143,11 +143,11 @@ public class Table extends MarkdownElement {
             }
 
             if (rows.indexOf(row) < rows.size() - 1) {
-                sb.append("\n");
+                sb.append(System.lineSeparator());
             }
 
             if (!headerSeperatorAdded) {
-                sb.append(headerSeperator).append("\n");
+                sb.append(headerSeperator).append(System.lineSeparator());
                 headerSeperatorAdded = true;
             }
         }

--- a/Source/MarkdownGenerator/src/main/java/net/steppschuh/markdowngenerator/text/code/CodeBlock.java
+++ b/Source/MarkdownGenerator/src/main/java/net/steppschuh/markdowngenerator/text/code/CodeBlock.java
@@ -21,7 +21,7 @@ public class CodeBlock extends Text {
 
     @Override
     public String getPredecessor() {
-        return "```" + language + "\n";
+        return "```" + language + System.lineSeparator();
     }
 
     @Override

--- a/Source/MarkdownGenerator/src/main/java/net/steppschuh/markdowngenerator/text/heading/Heading.java
+++ b/Source/MarkdownGenerator/src/main/java/net/steppschuh/markdowngenerator/text/heading/Heading.java
@@ -41,7 +41,7 @@ public class Heading extends Text {
     public String getSuccessor() {
         if (underlineStyle && level < 3) {
             char underlineChar = (level == 1) ? UNDERLINE_CHAR_1 : UNDERLINE_CHAR_2;
-            return "\n" + StringUtil.fillUpLeftAligned("", "" + underlineChar, value.toString().length());
+            return System.lineSeparator() + StringUtil.fillUpLeftAligned("", "" + underlineChar, value.toString().length());
         }
         return "";
     }

--- a/Source/MarkdownGenerator/src/main/java/net/steppschuh/markdowngenerator/text/quote/Quote.java
+++ b/Source/MarkdownGenerator/src/main/java/net/steppschuh/markdowngenerator/text/quote/Quote.java
@@ -23,7 +23,7 @@ public class Quote extends Text {
         for (int lineIndex = 0; lineIndex < lines.length; lineIndex++) {
             sb.append("> ").append(lines[lineIndex]);
             if (lineIndex < lines.length - 1) {
-                sb.append("\n");
+                sb.append(System.lineSeparator());
             }
         }
         return sb.toString();

--- a/Source/MarkdownGenerator/src/test/java/net/steppschuh/markdowngenerator/text/HeadingTest.java
+++ b/Source/MarkdownGenerator/src/test/java/net/steppschuh/markdowngenerator/text/HeadingTest.java
@@ -26,11 +26,11 @@ public class HeadingTest {
     @Test
     public void example3() throws Exception {
         StringBuilder sb = new StringBuilder()
-                .append(new Heading("Heading with level 1", 1)).append("\n")
-                .append(new Heading("Heading with level 2", 2)).append("\n")
-                .append(new Heading("Heading with level 3", 3)).append("\n")
-                .append(new Heading("Heading with level 4", 4)).append("\n")
-                .append(new Heading("Heading with level 5", 5)).append("\n")
+                .append(new Heading("Heading with level 1", 1)).append(System.lineSeparator())
+                .append(new Heading("Heading with level 2", 2)).append(System.lineSeparator())
+                .append(new Heading("Heading with level 3", 3)).append(System.lineSeparator())
+                .append(new Heading("Heading with level 4", 4)).append(System.lineSeparator())
+                .append(new Heading("Heading with level 5", 5)).append(System.lineSeparator())
                 .append(new Heading("Heading with level 6", 6));
 
         System.out.println(sb);


### PR DESCRIPTION
Currently the created markdown uses hardcoded "\n" line seperators. This fix changes the behaviour to use the java System.lineSeperator() method that uses the correct line seperator according to the current os environment.

Closes #7 