### PR TITLE
Fixed table containing only header generating broken markdown

### DIFF
--- a/Source/MarkdownGenerator/src/main/java/net/steppschuh/markdowngenerator/table/Table.java
+++ b/Source/MarkdownGenerator/src/main/java/net/steppschuh/markdowngenerator/table/Table.java
@@ -142,7 +142,7 @@ public class Table extends MarkdownElement {
                 }
             }
 
-            if (rows.indexOf(row) < rows.size() - 1) {
+            if (rows.indexOf(row) < rows.size() - 1 || rows.size() == 1) {
                 sb.append("\n");
             }
 

--- a/Source/MarkdownGenerator/src/test/java/net/steppschuh/markdowngenerator/table/TableTest.java
+++ b/Source/MarkdownGenerator/src/test/java/net/steppschuh/markdowngenerator/table/TableTest.java
@@ -58,4 +58,12 @@ public class TableTest {
         System.out.println(tableBuilder.build());
     }
 
+    @Test
+    public void example3() {
+        Table.Builder tableBuilder = new Table.Builder()
+                .addRow("Index", "Boolean");
+
+        System.out.println(tableBuilder.build());
+    }
+
 }


### PR DESCRIPTION
There was a line break missing when generating a table with only the header row.
This fixes this problem.